### PR TITLE
added support for the Fortran Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
 *.mod
 build/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cmake ../
 make
 sudo make install
 ```
-If you'd like to run the provided tests to verify your installation, 
+If you'd like to run the provided tests to verify your installation,
 1. Navigate to the `test/` directory underneath the `build/` directory.
 ```
 cd test/
@@ -28,6 +28,28 @@ The above steps install
 ```
 /opt/feqparse/lib/libfeqparse.a
 /opt/feqparse/include/FEQParse.mod
+```
+
+### Fortran Package Manager
+
+A [Fortran Package Manager](https://github.com/fortran-lang/fpm) manifest file is also included, so that the library and test cases can be compiled with FPM. For example:
+
+```
+fpm build --profile release
+fpm test --profile release
+```
+
+To use `feq-parse` within your fpm project, add the following to your `fpm.toml` file:
+```toml
+[dependencies]
+feq-parse = { git="https://github.com/FluidNumerics/feq-parse.git" }
+```
+
+Or, to use a specific version:
+
+```toml
+[dependencies]
+feq-parse = { git="https://github.com/FluidNumerics/feq-parse.git", tag = "v1.1.0" }
 ```
 
 ## Usage
@@ -61,14 +83,14 @@ IMPLICIT NONE
     ! Specify the independent variables
     independentVars = (/ 'x', 'y', 'z' /)
 
-    ! Specify an equation string that we want to evaluate 
+    ! Specify an equation string that we want to evaluate
     eqChar = 'f = exp( -(x^2 + y^2 + z^2) )'
 
     ! Create the EquationParser object
     f = EquationParser(eqChar, independentVars)
-   
-    ! Evaluate the equation 
-    x = (/ 0.0, 0.0, 0.0 /) 
+
+    ! Evaluate the equation
+    x = (/ 0.0, 0.0, 0.0 /)
     PRINT*, f % evaluate( x )
 
     ! Clean up memory

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,0 +1,18 @@
+name = "feq-parse"
+license = "Apache 2.0"
+author = "Fluid Numerics LLC"
+copyright = "Copyright 2020 Fluid Numerics LLC"
+description = "An equation parser class for Modern Fortran"
+homepage = "https://github.com/FluidNumerics/feq-parse"
+keywords = ["parser"]
+
+[build]
+auto-executables = false
+auto-examples = false
+auto-tests = true
+
+[library]
+source-dir = "src"
+
+[install]
+library = true

--- a/test/test.f90
+++ b/test/test.f90
@@ -1,0 +1,14 @@
+program test
+
+    !! a main program to include the test case, so it
+    !! can be compiled with FPM.
+
+    implicit none
+
+    write(*,*) gaussian3d()
+
+    contains
+
+    include "gaussian3d.f90"
+
+end program test


### PR DESCRIPTION
Here is a PR to add support for the [Fortran Package Manager](https://fpm.fortran-lang.org/en/index.html). Basically just added a `fpm.toml` file so that other projects can use the library as a dependency.