### PR TITLE
Fix Build with ifx/ifort

### DIFF
--- a/src/FEQParse_Functions.F90
+++ b/src/FEQParse_Functions.F90
@@ -262,10 +262,12 @@ module FEQParse_Functions
         func = name
         func%ptr32 => f_32
         func%ptr64 => null()
-        allocate(tmp(1:nFunctions + 1))
+        allocate(tmp, source = Functions)
+        deallocate(Functions)
+        allocate(Functions(nFunctions + 1))
         tmp(:nFunctions) = Functions(:nFunctions)
-        call move_alloc(tmp, Functions)
         Functions(nFunctions + 1) = func
+        deallocate(tmp)
         nFunctions = nFunctions + 1
     end subroutine
 
@@ -280,10 +282,12 @@ module FEQParse_Functions
         func = name
         func%ptr32 => null()
         func%ptr64 => f_64
-        allocate(tmp(1:nFunctions + 1))
+        allocate(tmp, source = Functions)
+        deallocate(Functions)
+        allocate(Functions(nFunctions + 1))
         tmp(:nFunctions) = Functions(:nFunctions)
-        call move_alloc(tmp, Functions)
         Functions(nFunctions + 1) = func
+        deallocate(tmp)
         nFunctions = nFunctions + 1
     end subroutine
 
@@ -299,10 +303,12 @@ module FEQParse_Functions
         func = name
         func%ptr32 => f_32
         func%ptr64 => f_64
-        allocate(tmp(1:nFunctions + 1))
+        allocate(tmp, source = Functions)
+        deallocate(Functions)
+        allocate(Functions(nFunctions + 1))
         tmp(:nFunctions) = Functions(:nFunctions)
-        call move_alloc(tmp, Functions)
         Functions(nFunctions + 1) = func
+        deallocate(tmp)
         nFunctions = nFunctions + 1
     end subroutine
 

--- a/src/FEQParse_Functions.F90
+++ b/src/FEQParse_Functions.F90
@@ -256,12 +256,16 @@ module FEQParse_Functions
         procedure(f32) :: f_32
         !private 
         type(FEQParse_Function) :: func
+        type(FEQParse_Function), allocatable :: tmp(:)
 
         call InitializeFunctions()
         func = name
         func%ptr32 => f_32
         func%ptr64 => null()
-        Functions = [Functions, func]
+        allocate(tmp(1:nFunctions + 1))
+        tmp(:nFunctions) = Functions(:nFunctions)
+        call move_alloc(tmp, Functions)
+        Functions(nFunctions + 1) = func
         nFunctions = nFunctions + 1
     end subroutine
 
@@ -270,12 +274,16 @@ module FEQParse_Functions
         procedure(f64) :: f_64
         !private 
         type(FEQParse_Function) :: func
+        type(FEQParse_Function), allocatable :: tmp(:)
 
         call InitializeFunctions()
         func = name
         func%ptr32 => null()
         func%ptr64 => f_64
-        Functions = [Functions, func]
+        allocate(tmp(1:nFunctions + 1))
+        tmp(:nFunctions) = Functions(:nFunctions)
+        call move_alloc(tmp, Functions)
+        Functions(nFunctions + 1) = func
         nFunctions = nFunctions + 1
     end subroutine
 
@@ -285,12 +293,16 @@ module FEQParse_Functions
         procedure(f64) :: f_64
         !private 
         type(FEQParse_Function) :: func
+        type(FEQParse_Function), allocatable :: tmp(:)
 
         call InitializeFunctions()
         func = name
         func%ptr32 => f_32
         func%ptr64 => f_64
-        Functions = [Functions, func]
+        allocate(tmp(1:nFunctions + 1))
+        tmp(:nFunctions) = Functions(:nFunctions)
+        call move_alloc(tmp, Functions)
+        Functions(nFunctions + 1) = func
         nFunctions = nFunctions + 1
     end subroutine
 


### PR DESCRIPTION
It looks like ifrot and ifx have an issue with automatic array reallocation upon assignment (which should be standard since f2003). 
I tried also using move_alloc instead, but the issue remained. Finally, I used a fixed length array for the functions (100) and removed the allocation part. 
All tests passed, but we are limited to 100 functions at max.  