### PR TITLE
Fix monadic token priority to resolve issue #31

### DIFF
--- a/src/FEQParse.F90
+++ b/src/FEQParse.F90
@@ -1686,6 +1686,10 @@ contains
 
         Priority = 1
 
+      else
+
+        Priority = 0
+
       endif
 
     elseif(toke%tokenType == Monadic_Token) then

--- a/src/FEQParse.F90
+++ b/src/FEQParse.F90
@@ -572,11 +572,9 @@ contains
       case(Monadic_Token)
 
         if(trim(t%tokenString) == '-') then
-
           call stack%Pop(a)
           a = -a
           call stack%Push(a)
-
         endif
 
       case default
@@ -1670,21 +1668,29 @@ contains
 
       Priority = 5
 
-    elseif(toke%tokenString(1:1) == '^') then
+    elseif(toke%tokenType == Operator_Token) then
 
-      Priority = 4
+      if(toke%tokenString(1:1) == '^') then
 
-    elseif(toke%tokenString(1:1) == '/') then
+        Priority = 4
 
-      Priority = 3
+      elseif(toke%tokenString(1:1) == '/') then
 
-    elseif(toke%tokenString(1:1) == '*') then
+        Priority = 3
 
-      Priority = 2
+      elseif(toke%tokenString(1:1) == '*') then
 
-    elseif(toke%tokenString(1:1) == '+' .or. toke%tokenString(1:1) == '-') then
+        Priority = 2
 
-      Priority = 1
+      elseif(toke%tokenString(1:1) == '+' .or. toke%tokenString(1:1) == '-') then
+
+        Priority = 1
+
+      endif
+
+    elseif(toke%tokenType == Monadic_Token) then
+
+      Priority = 5
 
     else
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -189,5 +189,6 @@ add_fortran_tests (
     "tan_sfp64.f90"
     "print_tokens.f90"
     "custom_r1fp64.f90"
-    "parsing_difficult_r1fp64.f90")
+    "parsing_difficult_r1fp64.f90"
+    "parsing_vanderpol_sfp64.f90")
     

--- a/test/parsing_vanderpol_sfp64.f90
+++ b/test/parsing_vanderpol_sfp64.f90
@@ -1,0 +1,51 @@
+program test
+
+  implicit none
+  integer :: exit_code
+
+  exit_code = vanderpol_sfp64()
+  stop exit_code
+
+contains
+
+  integer function vanderpol_sfp64() result(r)
+    use FEQParse
+    use iso_fortran_env
+    implicit none
+    integer,parameter :: N = 10
+    type(EquationParser) :: f
+    character(len=128) :: fun_buf
+    real(real64) :: t,x,y,u,v
+    real(real64) :: feval
+    real(real64) :: fexact
+
+    fun_buf = '-8.53*(1-x*x)*v-y'
+    f = equationparser('f = '//fun_buf,['t','x','y','u','v'])
+
+    print*,"--------- Infix -------------------"
+    call f%Print_InFixTokens()
+    print*,"-----------------------------------"
+    print*,"--------- Postfix -------------------"
+    call f%Print_PostFixTokens()
+    print*,"-----------------------------------"
+
+    t = 0.0_real64
+    x = 1.0_real64
+    y = 3.0_real64
+    u = 12.0_real64
+    v = 0.0_real64
+
+    feval = f%evaluate([t,x,y,u,v])
+
+    fexact = -8.53_real64*(1.0_real64-x*x)*v-y
+
+    if((abs(feval-fexact)) <= epsilon(1.0_real64)) then
+      r = 0
+      print*,feval,fexact
+    else
+      r = 1
+      print*,feval,fexact
+    endif
+
+  endfunction vanderpol_sfp64
+endprogram test


### PR DESCRIPTION
The priority function, which is used in infix to postfix conversion, has been updated to separate out function, operator, and monad token types and assign priority for order of operations within each class. Functions and monads take highest priority; Monads ( negative signs in front of numbers, variables, and parentheses) need highest priority so that  the sign flip is applied immediately after a number or variable is pushed on to the evaluation stack.

A new test is added, based on the MWE from @angelog0 in issue #31 to ensure this issue remains covered in tests

Resolves #31 