### PR TITLE
Add fp32 test for custom function

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -188,6 +188,7 @@ add_fortran_tests (
     "tan_sfp32.f90"
     "tan_sfp64.f90"
     "print_tokens.f90"
+    "custom_r1fp32.f90"
     "custom_r1fp64.f90"
     "parsing_difficult_r1fp64.f90"
     "parsing_vanderpol_sfp64.f90")

--- a/test/custom_r1fp32.f90
+++ b/test/custom_r1fp32.f90
@@ -1,0 +1,33 @@
+program test
+  use iso_fortran_env,only:i1 => int8,i2 => int16,i4 => int32,i8 => int64, &
+                            r4 => real32,r8 => real64,r16 => real128
+  use FEQParse
+
+  implicit none
+
+  write(*,'(A,I20)') "test ",testing()
+
+contains
+
+  integer function testing() result(r)
+    !private
+    type(EquationParser) :: f
+    real(r4) :: feval
+
+    call AddFunction("myfunc",myfunc32)
+
+    f = EquationParser("MYFUNC(x)",["x"])
+
+    feval = f%evaluate([1.0_r4])
+    if((abs(feval-0.5_r4)) <= epsilon(1.0_r4)) then
+      r = 0
+    else
+      r = 1
+    endif
+  endfunction
+
+  pure real(r4) function myfunc32(x)
+    real(r4),intent(in) :: x
+    myfunc32 = x/2.0_r4
+  endfunction
+endprogram


### PR DESCRIPTION
This PR is intended to increase coverage, in relation to untested routines for adding custom functions (fp32 tests were missing previously). Additionally, we're adding an example to the `examples/` subdirectory to demonstrate how to specify custom functions that are consistent with the `fp32` and `fp64` interfaces.

Closes issue #35 