### PR TITLE
Remove functions attribute from equationparser type

### DIFF
--- a/src/FEQParse.F90
+++ b/src/FEQParse.F90
@@ -61,7 +61,6 @@ module FEQParse
     type(IndepVar),dimension(:),allocatable   :: indepVars
     type(TokenStack)                            :: inFix
     type(TokenStack)                            :: postFix
-    type(FEQParse_Function),dimension(:),allocatable :: functions
   contains
     procedure :: CleanEquation
     procedure :: Tokenize


### PR DESCRIPTION
Functions (array of feqparse_function) is exposed as a public module variable already. The functions attribute is never referenced.